### PR TITLE
eslint configuration change in server/.eslintrc

### DIFF
--- a/server/.eslintrc
+++ b/server/.eslintrc
@@ -1,5 +1,5 @@
 {
-    "extends": ["airbnb", "prettier"],
+    "extends": ["airbnb-base", "prettier"],
     "parser": "@babel/eslint-parser",
     "plugins": [
       "prettier"

--- a/server/.eslintrc
+++ b/server/.eslintrc
@@ -15,7 +15,12 @@
         "allowImportExportEverywhere": true
     },
     "rules": {
-        "prettier/prettier": "error",
+        "prettier/prettier": [
+            "error",
+            {
+                "endOfLine": "auto"
+            }
+        ],
         "import/no-unresolved": 0,
         "import/no-absolute-path": 0,
         "import/extensions": 0,

--- a/server/.eslintrc
+++ b/server/.eslintrc
@@ -15,6 +15,12 @@
         "allowImportExportEverywhere": true
     },
     "rules": {
+        "prettier/prettier": [
+            "error",
+            {
+                "endOfLine": "auto"
+            }
+        ],
         "import/no-unresolved": 0,
         "import/no-absolute-path": 0,
         "import/extensions": 0,

--- a/server/.eslintrc
+++ b/server/.eslintrc
@@ -1,5 +1,5 @@
 {
-    "extends": ["airbnb-base", "prettier"],
+    "extends": ["airbnb", "prettier"],
     "parser": "@babel/eslint-parser",
     "plugins": [
       "prettier"
@@ -15,12 +15,6 @@
         "allowImportExportEverywhere": true
     },
     "rules": {
-        "prettier/prettier": [
-            "error",
-            {
-                "endOfLine": "auto"
-            }
-        ],
         "import/no-unresolved": 0,
         "import/no-absolute-path": 0,
         "import/extensions": 0,


### PR DESCRIPTION
In `server/.eslintrc`  extends `airbnb`. But `airbnb `by default required other packages related to react. https://github.com/airbnb/javascript/tree/master/packages/eslint-config-airbnb#eslint-config-airbnb-1 If these packages are not installed error occurred.  ![eslint_error_server](https://user-images.githubusercontent.com/23289126/156724374-737d3bd9-d9f4-468d-bb3e-c80493940624.PNG) It is better to use `airbnb-base` insted of `airbnb `when no need to use react. 

Line breaks of files are different in different OS. As I try to run the lint command in windows I get this error - 
![linux_error_eslint](https://user-images.githubusercontent.com/23289126/156724747-b542a319-b8e2-43ae-a0d8-7dca374168eb.PNG) So I change `endOfLine` rule to fit in OS.
.